### PR TITLE
Success handling service: create new success handling service to noti…

### DIFF
--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -29,6 +29,7 @@ import { IssueService } from './core/services/issue.service';
 import { LoggingService } from './core/services/logging.service';
 import { PhaseService } from './core/services/phase.service';
 import { SessionFixConfirmationComponent } from './core/services/session-fix-confirmation/session-fix-confirmation.component';
+import { SuccessHandlingService } from './core/services/success-handling.service';
 import { UserService } from './core/services/user.service';
 import { PhaseBugReportingModule } from './phase-bug-reporting/phase-bug-reporting.module';
 import { PhaseModerationModule } from './phase-moderation/phase-moderation.module';
@@ -65,7 +66,7 @@ import { SharedModule } from './shared/shared.module';
     {
       provide: GithubService,
       useFactory: GithubServiceFactory,
-      deps: [ErrorHandlingService, Apollo, ElectronService, LoggingService]
+      deps: [ErrorHandlingService, Apollo, ElectronService, LoggingService, SuccessHandlingService]
     },
     {
       provide: AuthService,

--- a/src/app/core/services/success-handling.service.ts
+++ b/src/app/core/services/success-handling.service.ts
@@ -1,0 +1,16 @@
+import { Injectable } from '@angular/core';
+import { MatSnackBar } from '@angular/material';
+import { SuccessActionComponent } from '../../shared/action-toasters/success-action/success-action.component';
+import { LoggingService } from './logging.service';
+
+@Injectable({
+  providedIn: 'root'
+})
+export class SuccessHandlingService {
+  constructor(private snackBar: MatSnackBar, private logger: LoggingService) {}
+
+  handleSuccess(message: string) {
+    this.logger.info(message);
+    this.snackBar.openFromComponent(SuccessActionComponent, { data: { message: message } });
+  }
+}

--- a/src/app/phase-bug-reporting/new-issue/new-issue.component.ts
+++ b/src/app/phase-bug-reporting/new-issue/new-issue.component.ts
@@ -6,6 +6,7 @@ import { Issue } from '../../core/models/issue.model';
 import { ErrorHandlingService } from '../../core/services/error-handling.service';
 import { IssueService } from '../../core/services/issue.service';
 import { LabelService } from '../../core/services/label.service';
+import { SuccessHandlingService } from '../../core/services/success-handling.service';
 import { SUBMIT_BUTTON_TEXT } from '../../shared/view-issue/view-issue.component';
 
 @Component({
@@ -22,6 +23,7 @@ export class NewIssueComponent implements OnInit {
     private issueService: IssueService,
     private formBuilder: FormBuilder,
     private errorHandlingService: ErrorHandlingService,
+    private successHandlingService: SuccessHandlingService,
     public labelService: LabelService,
     private router: Router
   ) {}
@@ -53,6 +55,9 @@ export class NewIssueComponent implements OnInit {
         },
         (error) => {
           this.errorHandlingService.handleError(error);
+        },
+        () => {
+          this.successHandlingService.handleSuccess('Successfully submitted new issue');
         }
       );
   }

--- a/src/app/shared/action-toasters/action-toasters.module.ts
+++ b/src/app/shared/action-toasters/action-toasters.module.ts
@@ -1,12 +1,13 @@
 import { CommonModule } from '@angular/common';
 import { NgModule } from '@angular/core';
 import { MaterialModule } from '../material.module';
+import { SuccessActionComponent } from './success-action/success-action.component';
 import { UndoActionComponent } from './undo-action/undo-action.component';
 
 @NgModule({
   imports: [CommonModule, MaterialModule],
-  declarations: [UndoActionComponent],
-  exports: [UndoActionComponent],
-  entryComponents: [UndoActionComponent]
+  declarations: [UndoActionComponent, SuccessActionComponent],
+  exports: [UndoActionComponent, SuccessActionComponent],
+  entryComponents: [UndoActionComponent, SuccessActionComponent]
 })
 export class ActionToasterModule {}

--- a/src/app/shared/action-toasters/success-action/success-action.component.html
+++ b/src/app/shared/action-toasters/success-action/success-action.component.html
@@ -1,0 +1,2 @@
+<p style="display: inline-block; max-width: 300px">{{ data.message }}</p>
+<button style="float: right; margin-top: 8px" mat-button color="accent" (click)="snackBarRef.dismiss()">Close</button>

--- a/src/app/shared/action-toasters/success-action/success-action.component.ts
+++ b/src/app/shared/action-toasters/success-action/success-action.component.ts
@@ -1,0 +1,10 @@
+import { Component, Inject } from '@angular/core';
+import { MAT_SNACK_BAR_DATA, MatSnackBarRef } from '@angular/material';
+
+@Component({
+  selector: 'app-success-action',
+  templateUrl: './success-action.component.html'
+})
+export class SuccessActionComponent {
+  constructor(public snackBarRef: MatSnackBarRef<SuccessActionComponent>, @Inject(MAT_SNACK_BAR_DATA) public data: any) {}
+}

--- a/tests/app/phase-bug-reporting/new-issue.component.spec.ts
+++ b/tests/app/phase-bug-reporting/new-issue.component.spec.ts
@@ -3,7 +3,7 @@ import { NewIssueComponent } from '../../../src/app/phase-bug-reporting/new-issu
 
 describe('NewIssueComponent', () => {
   let newIssueComponent: NewIssueComponent;
-  newIssueComponent = new NewIssueComponent(null, new FormBuilder(), null, null, null);
+  newIssueComponent = new NewIssueComponent(null, new FormBuilder(), null, null, null, null);
 
   describe('.isAttributeEditing()', () => {
     beforeEach(() => {


### PR DESCRIPTION
Users are mostly notified when there are errors. This PR adds success notifications as well to let the user know their action of submitting a new issue was successful, giving them more peace of mind when submitting issues. 

![success](https://user-images.githubusercontent.com/67156011/173235458-b32c2827-a1e3-465a-ba5b-959b36639bcd.gif)
